### PR TITLE
packages: containerd: fix version scraping

### DIFF
--- a/packages/docker/container_sync_obs.sh
+++ b/packages/docker/container_sync_obs.sh
@@ -5,7 +5,11 @@ cd $(dirname $0)
 . ../../package_sync_functions.sh
 
 containerd_git_version() {
-  echo $(cat version.go | grep "const Version" | sed -E 's/.*= "(.*)"$/\1/g')
+  for tp in {Major,Minor,Patch}; do
+	  eval $tp=$(cat version.go | grep "const Version$tp" | sed -E 's/.*= ([0-9]*)$/\1/g')
+  done
+
+  echo "$Major.$Minor.$Patch"
 }
 
 package_sync_build_service https://api.opensuse.org Virtualization:containers:experimental containerd  https://github.com/docker/containerd.git containerd_git_version


### PR DESCRIPTION
containerd has switched (since ba465c17a7628) to having separate
numerical constants to define the version number. Update the relevant
script so that we can generate the version properly.

Signed-off-by: Aleksa Sarai asarai@suse.de

/cc @jordimassaguerpla 
