### PR TITLE
packages: runc: fix version scraping

### DIFF
--- a/packages/docker/runc_sync_obs.sh
+++ b/packages/docker/runc_sync_obs.sh
@@ -5,7 +5,7 @@ cd $(dirname $0)
 . ../../package_sync_functions.sh
 
 runc_git_version() {
-  echo $(cat main.go | grep 'version\s*=' | sed -E 's/.*=\s+"(.*)"$/\1/g')
+	echo $(cat VERSION)
 }
 
 package_sync_build_service https://api.opensuse.org Virtualization:containers:experimental runc https://github.com/opencontainers/runc.git runc_git_version


### PR DESCRIPTION
runC has switched (since 152ee95380ef1) to using a single VERSION file
to define the version. Update the relevant script so that we can
generate the version properly.

Signed-off-by: Aleksa Sarai asarai@suse.de

/cc @jordimassaguerpla 
