### PR TITLE
Fixed rpm versioning for docker

### DIFF
--- a/packages/docker/docker_sync_obs.sh
+++ b/packages/docker/docker_sync_obs.sh
@@ -5,11 +5,10 @@ cd $(dirname $0)
 . ../../package_sync_functions.sh
 
 docker_git_version() {
-	cat VERSION | grep -q ".0-dev"
-	if [ $? == 0 ]; then
-		echo $(cat VERSION | sed "s/\.0-dev/~def/")
+	if grep -q -- '.0-dev' VERSION; then
+		echo $(cat VERSION | sed "s/\.0-dev/~dev/")
 	else
-		echo $(cat VERSION | sed "s/-dev/~def/")
+		echo $(cat VERSION | sed "s/-dev/~dev/")
 	fi
 }
 

--- a/packages/docker/runc_sync_obs.sh
+++ b/packages/docker/runc_sync_obs.sh
@@ -5,7 +5,11 @@ cd $(dirname $0)
 . ../../package_sync_functions.sh
 
 runc_git_version() {
-	echo $(cat VERSION)
+	if grep -q -- '.0-rc[0-9]' VERSION; then
+		echo $(cat VERSION | sed "s/\.0-rc[0-9]/~dev/")
+	else
+		echo $(cat VERSION | sed "s/-rc[0-9]/~dev/")
+	fi
 }
 
 package_sync_build_service https://api.opensuse.org Virtualization:containers:experimental runc https://github.com/opencontainers/runc.git runc_git_version


### PR DESCRIPTION
Fixed a typo in the docker experimental versioning format, it should be
~dev instead of ~def.

Signed-off-by: Thomas Boerger thomas@webhippie.de
